### PR TITLE
always capture eval error when call retry if

### DIFF
--- a/lib/Sub/Retry.pm
+++ b/lib/Sub/Retry.pm
@@ -12,24 +12,28 @@ sub retry {
     my ( $times, $delay, $code, $retry_if ) = @_;
 
     my $err;
-    $retry_if ||= sub { $err = $@ };
+    $retry_if ||= sub { $err };
+
     my $n = 0;
     while ( $times-- > 0 ) {
         $n++;
         if (wantarray) {
             my @ret = eval { $code->($n) };
+            $err = $@;
             unless ($retry_if->(@ret)) {
                 return @ret;
             }
         }
         elsif (not defined wantarray) {
             eval { $code->($n) };
+            $err = $@;
             unless ($retry_if->()) {
                 return;
             }
         }
         else {
             my $ret = eval { $code->($n) };
+            $err = $@;
             unless ($retry_if->($ret)) {
                 return $ret;
             }


### PR DESCRIPTION
When using `retry_if` callback, the exception propagation is not works.

The previous implementation collects exception by default `retry_if` callback.
So it veils the exception that occurred in the main callback when `retry_if` callback is override.

I think exceptions should always be propagated, as this causes problems that are hard to notice.